### PR TITLE
Richtext component `rest`property

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prismic-reactjs",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prismic-reactjs",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "render prismic rich text as React Element",
   "main": "dist/prismic-reactjs.js",
   "scripts": {

--- a/src/Component.js
+++ b/src/Component.js
@@ -17,7 +17,8 @@ const RichText = ({
   linkResolver,
   render,
   renderAsText,
-  serializeHyperlink
+  serializeHyperlink,
+  ...rest
 }) => {
   const maybeSerializer = htmlSerializer || (serializeHyperlink &&
     createHtmlSerializer({}, [{
@@ -27,7 +28,7 @@ const RichText = ({
   );
 
   return render ?
-    renderRichText(render, linkResolver, maybeSerializer, Component)
+    renderRichText(render, linkResolver, maybeSerializer, Component, rest)
     : null;
 }
 

--- a/src/richtext.js
+++ b/src/richtext.js
@@ -103,11 +103,11 @@ function serializeEmbed(element, key) {
 
 export const asText = structuredText => PrismicRichText.asText(structuredText)
 
-export const renderRichText = (richText, linkResolver, htmlSerializer, Component = Fragment) => {
+export const renderRichText = (richText, linkResolver, htmlSerializer, Component = Fragment, args = {}) => {
   if (Object.prototype.toString.call(richText) !== '[object Array]') {
     console.warn(`Rich text argument should be an Array. Received ${typeof richtext}`);
     return null;
   }
   const serializedChildren = PrismicRichText.serialize(richText, serialize.bind(null, linkResolver), htmlSerializer);
-  return createElement(Component, propsWithUniqueKey(), serializedChildren);
+  return createElement(Component, args, serializedChildren);
 }

--- a/test/richtext.js
+++ b/test/richtext.js
@@ -52,4 +52,20 @@ describe('richtext', () => {
     expect(items.at(0).key()).to.equal('0');
     expect(items.at(1).key()).to.equal('1');
   });
+
+  it('renders an HTML element with attribute corresponding to any given args', () => {
+    const richText = [{
+      type: 'heading2',
+      text: 'Heading',
+      spans: [],
+    }];
+
+    const args = {
+      className: "definedClassName",
+      width: 250,
+    }
+    const wrapper = shallow(renderRichText(richText, null, null, 'div', args));
+    expect(wrapper.prop('width')).to.equal(250);
+    expect(wrapper.prop('className')).to.equal('definedClassName');
+  })
 });


### PR DESCRIPTION
Following #35, we needed a way to pass props (like `className`) to the wrapper element created by RichText.

Given this call to RichText:
```javascript
<RichText
 render={myField}
 Component="div"
 className="my-class-name"
 data-attribute="data"
/>
````
Your HTML markup should end up like this:
```html
<div class="my-class-name" data-attribute="data">
    /* ... */
</div>
````

Note: users might forget that wrapper Component defaults to `React.Fragment` and therefore will not pass rest properly.