### PR TITLE
Rich Text Typings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,9 +132,6 @@ build/Release
 node_modules/
 jspm_packages/
 
-# Typescript v1 declaration files
-typings/
-
 # Optional npm cache directory
 .npm
 

--- a/package.json
+++ b/package.json
@@ -45,5 +45,6 @@
     "webpack-bundle-analyzer": "^3.4.1",
     "webpack-cli": "^3.3.0",
     "yargs": "^13.2.2"
-  }
+  },
+  "typings": "typings/index.d.ts"
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,0 +1,71 @@
+interface Elements {
+  heading1: 'heading1';
+  heading2: 'heading2';
+  heading3: 'heading3';
+  heading4: 'heading4';
+  heading5: 'heading5';
+  heading6: 'heading6';
+  paragraph: 'paragraph';
+  preformatted: 'preformatted';
+  strong: 'strong';
+  em: 'em';
+  listItem: 'list-item';
+  oListItem: 'o-list-item';
+  list: 'group-list-item';
+  oList: 'group-o-list-item';
+  image: 'image';
+  embed: 'embed';
+  hyperlink: 'hyperlink';
+  label: 'label';
+  span: 'span';
+}
+
+type ElementType = Elements[keyof Elements];
+
+type HTMLSerializer<T> = (
+  type: ElementType,
+  element: any,
+  text: string | null,
+  children: T[],
+  index: number,
+) => T;
+
+declare class Richtext extends React.Component<RichTextProps, any>() {
+  asText<string>(): string;
+  displayName: string = 'RichText';
+  asHtml(
+    richText: any,
+    linkResolver?: (doc: any) => string,
+    serializer?: HTMLSerializer<string>,
+  ): string;
+  renderRichText<any>(): React.DOMElement;
+  Elements: Elements
+}
+
+interface RichTextProps {
+  Component?: React.ReactNode;
+  htmlSerializer?: HTMLSerializer<string>;
+  linkResolver<any>(): string;
+  serializeHyperlink<any>();
+  render<any>(): React.DOMElement;
+  renderAsText<any>(): string;
+}
+
+interface Link {
+  url(link: any, linkResolver?: (doc: any) => string): string;
+}
+
+export const RichText: RichText;
+export const Link: Link;
+export const HTMLSerializer: HTMLSerializer<string>;
+export const Date: Date = <string>(): Date => { };
+
+
+declare const _default: {
+  RichText: RichText,
+  Elements: ElementType,
+  Link: Link,
+  Date: Date = <string>(): Date => { },
+};
+
+export default _default;


### PR DESCRIPTION
In order to fix the following issue : #42 
Implementing a definition type for : RichText stateless component.

- Elements
- RichText
- Date
- Link

The _Date_ export might be called differently in the future, to avoid overwriting the default **Date** JS class.