### PR TITLE
Declaring `RichText` exports to class `Richtext` (lowercase T)

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -55,14 +55,14 @@ interface Link {
   url(link: any, linkResolver?: (doc: any) => string): string;
 }
 
-export const RichText: RichText;
+export const RichText: Richtext;
 export const Link: Link;
 export const HTMLSerializer: HTMLSerializer<string>;
 export const Date: Date = <string>(): Date => { };
 
 
 declare const _default: {
-  RichText: RichText,
+  RichText: Richtext,
   Elements: ElementType,
   Link: Link,
   Date: Date = <string>(): Date => { },


### PR DESCRIPTION
I believe this is a typo.  Currently the `RichText` export type is `any` instead using the `Richtext` class