### PR TITLE
Simplify html-serializer switch statement matching.

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,26 +1,24 @@
-interface Elements {
-  heading1: 'heading1';
-  heading2: 'heading2';
-  heading3: 'heading3';
-  heading4: 'heading4';
-  heading5: 'heading5';
-  heading6: 'heading6';
-  paragraph: 'paragraph';
-  preformatted: 'preformatted';
-  strong: 'strong';
-  em: 'em';
-  listItem: 'list-item';
-  oListItem: 'o-list-item';
-  list: 'group-list-item';
-  oList: 'group-o-list-item';
-  image: 'image';
-  embed: 'embed';
-  hyperlink: 'hyperlink';
-  label: 'label';
-  span: 'span';
-}
-
-type ElementType = Elements[keyof Elements];
+enum Elements {
+  heading1 = 'heading1',
+  heading2 = 'heading2',
+  heading3 = 'heading3',
+  heading4 = 'heading4',
+  heading5 = 'heading5',
+  heading6 = 'heading6',
+  paragraph = 'paragraph',
+  preformatted = 'preformatted',
+  strong = 'strong',
+  em = 'em',
+  listItem = 'list-item',
+  oListItem = 'o-list-item',
+  list = 'group-list-item',
+  oList = 'group-o-list-item',
+  image = 'image',
+  embed = 'embed',
+  hyperlink = 'hyperlink',
+  label = 'label',
+  span = 'span',
+};
 
 type HTMLSerializer<T> = (
   type: ElementType,
@@ -63,7 +61,7 @@ export const Date: Date = <string>(): Date => { };
 
 declare const _default: {
   RichText: RichText,
-  Elements: ElementType,
+  Elements: Elements,
   Link: Link,
   Date: Date = <string>(): Date => { },
 };


### PR DESCRIPTION
Remove the need for an html-serializer switch statement to require a hard-coded string to match to an element type.

From 
```
switch (type) {
    case 'heading1': {
      return <H1 key={key}>{children}</H1>
    }
    case 'heading2': {
      return <H2 key={key}>{children}</H2>
    }
...
```

To:

```
import PrismicJS from 'prismic-reactjs'
const { Elements } = PrismicJS


switch (type) {
    case Elements.heading1: {
      return <H1 key={key}>{children}</H1>
    }
    case Elements.heading2: {
      return <H2 key={key}>{children}</H2>
    }
...
```