### PR TITLE
Proposed TypeScript typings #42

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,71 +1,49 @@
-interface Elements {
-  heading1: 'heading1';
-  heading2: 'heading2';
-  heading3: 'heading3';
-  heading4: 'heading4';
-  heading5: 'heading5';
-  heading6: 'heading6';
-  paragraph: 'paragraph';
-  preformatted: 'preformatted';
-  strong: 'strong';
-  em: 'em';
-  listItem: 'list-item';
-  oListItem: 'o-list-item';
-  list: 'group-list-item';
-  oList: 'group-o-list-item';
-  image: 'image';
-  embed: 'embed';
-  hyperlink: 'hyperlink';
-  label: 'label';
-  span: 'span';
+enum Elements {
+  heading1 = 'heading1',
+  heading2 = 'heading2',
+  heading3 = 'heading3',
+  heading4 = 'heading4',
+  heading5 = 'heading5',
+  heading6 = 'heading6',
+  paragraph = 'paragraph',
+  preformatted = 'preformatted',
+  strong = 'strong',
+  em = 'em',
+  listItem = 'list-item',
+  oListItem = 'o-list-item',
+  list = 'group-list-item',
+  oList = 'group-o-list-item',
+  image = 'image',
+  embed = 'embed',
+  hyperlink = 'hyperlink',
+  label = 'label',
+  span = 'span',
 }
 
-type ElementType = Elements[keyof Elements];
-
-type HTMLSerializer<T> = (
+export type HTMLSerializer<T> = (
   type: ElementType,
   element: any,
   text: string | null,
   children: T[],
-  index: number,
+  index: number
 ) => T;
-
-declare class Richtext extends React.Component<RichTextProps, any>() {
-  asText<string>(): string;
-  displayName: string = 'RichText';
-  asHtml(
-    richText: any,
-    linkResolver?: (doc: any) => string,
-    serializer?: HTMLSerializer<string>,
-  ): string;
-  renderRichText<any>(): React.DOMElement;
-  Elements: Elements
+export interface RichTextProps {
+  Component?: React.ReactNode;
+  htmlSerializer?: HTMLSerializer<T>;
+  linkResolver?: () => string;
+  serializeHyperlink?: () => string;
+  render: () => React.DOMElement;
 }
 
-interface RichTextProps {
-  Component?: React.ReactNode;
-  htmlSerializer?: HTMLSerializer<string>;
-  linkResolver<any>(): string;
-  serializeHyperlink<any>();
-  render<any>(): React.DOMElement;
-  renderAsText<any>(): string;
+class RichText extends React.Component<RichTextProps, any> {
+  static asText(text: string): string;
 }
 
 interface Link {
   url(link: any, linkResolver?: (doc: any) => string): string;
 }
 
-export const RichText: RichText;
-export const Link: Link;
-export const HTMLSerializer: HTMLSerializer<string>;
-export const Date: Date = <string>(): Date => { };
+const Link: Link;
+const Date: Date = <string>(): Date => {};
 
-
-declare const _default: {
-  RichText: RichText,
-  Elements: ElementType,
-  Link: Link,
-  Date: Date = <string>(): Date => { },
-};
-
-export default _default;
+export { RichText, Elements, Link, Date };


### PR DESCRIPTION
Suggest updated typings for issue #42 

I am not completely familiar with the libraries and dependencies but these typings should be a bit clearer and usable.  

Currently the project does not build typings into its distribution, so I have copied these typings into my project as such:

```typescript
declare module 'prismic-reactjs' {
  import React from 'react';

  enum Elements {
    heading1 = 'heading1',
    heading2 = 'heading2',
    heading3 = 'heading3',
    heading4 = 'heading4',
    heading5 = 'heading5',
    heading6 = 'heading6',
    paragraph = 'paragraph',
    preformatted = 'preformatted',
    strong = 'strong',
    em = 'em',
    listItem = 'list-item',
    oListItem = 'o-list-item',
    list = 'group-list-item',
    oList = 'group-o-list-item',
    image = 'image',
    embed = 'embed',
    hyperlink = 'hyperlink',
    label = 'label',
    span = 'span',
  }

  export type HTMLSerializer<T> = (
    type: ElementType,
    element: any,
    text: string | null,
    children: T[],
    index: number
  ) => T;
  export interface RichTextProps {
    Component?: React.ReactNode;
    htmlSerializer?: HTMLSerializer<T>;
    linkResolver?: () => string;
    serializeHyperlink?: () => string;
    render: () => React.DOMElement;
  }

  class RichText extends React.Component<RichTextProps, any> {
    static asText(text: string): string;
  }

  interface Link {
    url(link: any, linkResolver?: (doc: any) => string): string;
  }

  const Link: Link;
  const Date: Date = <string>(): Date => {};

  export { RichText, Elements, Link, Date };
}

```