### PR TITLE
Update types for HTMLSerializer, RichTextBlock, and RichTextSpan

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,35 +22,42 @@ declare module "prismic-reactjs" {
 		span = "span",
 	}
 
+	type Link = {
+		link_type?: "Web" | "Document" | "Media" | "Any"
+		url?: string
+		target?: string
+		id?: string
+		uid?: string
+		isBroken?: boolean
+		lang?: string
+		slug?: string
+		tags?: string[]
+		type?: string
+		height?: string
+		kind?: string
+		name?: string
+		size?: string
+		width?: string
+	}
+
 	export type RichTextSpan = {
 		start: number;
 		end: number;
 		type: Elements.strong | Elements.hyperlink | Elements.em | Elements.label;
-		data?: {
-			link_type?: "Document" | "Web" | "Media" | "Any"
-			url?: string
-			id?: string
-			lang?: string
-			slug?: string
-			tags?: string[]
-			type?: string
-			uid?: string
-			isBroken?: boolean
-			target?: string
-			label?: string
-			data?: any
-		};
+		data?: Link & { label?: string }
 	};
 
 	export type RichTextBlock = {
 		type: Elements;
 		text?: string;
 		spans?: RichTextSpan[];
-		alt?: string
-		copyright?: string
+		alt?: string | null
+		copyright?: string | null
 		dimensions?: { width: number, height: number }
 		url?: string
-	};
+		linkTo?: Link
+		oembed?: any
+	}
 
 	export type HTMLSerializer<T> = (
 		type: Elements,

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,9 +27,18 @@ declare module "prismic-reactjs" {
 		end: number;
 		type: Elements.strong | Elements.hyperlink | Elements.em | Elements.label;
 		data?: {
-			link_type: string;
-			url: string;
-			target?: string;
+			link_type?: "Document" | "Web" | "Media" | "Any"
+			url?: string
+			id?: string
+			lang?: string
+			slug?: string
+			tags?: string[]
+			type?: string
+			uid?: string
+			isBroken?: boolean
+			target?: string
+			label?: string
+			data?: any
 		};
 	};
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ declare module "prismic-reactjs" {
 	export type RichTextSpan = {
 		start: number;
 		end: number;
-		type: "strong" | "hyperlink";
+		type: Elements.strong | Elements.hyperlink | Elements.em;
 		data?: {
 			link_type: string;
 			url: string;
@@ -35,12 +35,16 @@ declare module "prismic-reactjs" {
 
 	export type RichTextBlock = {
 		type: Elements;
-		text: string;
-		spans: RichTextSpan[];
+		text?: string;
+		spans?: RichTextSpan[];
+		alt?: string
+		copyright?: string
+		dimensions?: { width: number, height: number }
+		url?: string
 	};
 
 	export type HTMLSerializer<T> = (
-		type: React.ElementType,
+		type: Elements,
 		element: any,
 		content: string,
 		children: T[],
@@ -51,7 +55,7 @@ declare module "prismic-reactjs" {
 		Component?: React.ReactNode;
 		elements?: {};
 		htmlSerializer?: HTMLSerializer<React.ReactNode>;
-		linkResolver?: () => string;
+		linkResolver?: LinkResolver;
 		render?: RichTextBlock[];
 		renderAsText?: any;
 		serializeHyperlink?: () => React.ReactNode;
@@ -63,12 +67,14 @@ declare module "prismic-reactjs" {
 		displayName: "RichText";
 	};
 
+	export type LinkResolver = (doc: any) => string
+
 	interface LinkProps {
-		url(link: any, linkResolver?: (doc: any) => string): string;
+		url(link: any, linkResolver?: LinkResolver): string;
 	}
 
 	export const Link: React.FC<LinkProps> & {
-		url: (link: any, linkResolver?: (doc: any) => string) => string;
+		url: (link: any, linkResolver?: LinkResolver) => string;
 	};
 
 	interface PrismicDate {

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ declare module "prismic-reactjs" {
 	export type RichTextSpan = {
 		start: number;
 		end: number;
-		type: Elements.strong | Elements.hyperlink | Elements.em;
+		type: Elements.strong | Elements.hyperlink | Elements.em | Elements.label;
 		data?: {
 			link_type: string;
 			url: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -58,7 +58,7 @@ declare module "prismic-reactjs" {
 		linkResolver?: LinkResolver;
 		render?: RichTextBlock[];
 		renderAsText?: any;
-		serializeHyperlink?: () => React.ReactNode;
+		serializeHyperlink?: HTMLSerializer<React.ReactNode>;
 	}
 
 	export const RichText: React.FC<RichTextProps> & {


### PR DESCRIPTION
I ran into a few odd errors while trying to write an HTML serializer using these typings. Namely:
- `RichTextSpan`'s type property not accepting "em," which I think is valid
- The function passed to the `linkResolver` prop not expecting any arguments
- HTMLSerializer's `type` argument not corresponding with with RichTextBlock's `type`

I also made `text` and `spans` optional on `RichTextBlock`, because it can be an `Elements.image` type in some cases, and these have props like `url`, `dimensions`, `alt`, and `copyright`.

Let me know if I missed anything, I haven't tested every single rich text type yet.

Thanks for putting TypeScript typings in the repo. Much appreciated.

