### PR TITLE
feat: add `fallback` prop to `<PrismicRichText>` which is rendered when given an empty field

### DIFF
--- a/src/PrismicRichText.tsx
+++ b/src/PrismicRichText.tsx
@@ -79,6 +79,12 @@ export type PrismicRichTextProps = {
 	 * @defaultValue `<a>`
 	 */
 	externalLinkComponent?: PrismicLinkProps["externalComponent"];
+
+	/**
+	 * The value to be rendered when the field is empty. If a fallback is not
+	 * given, `null` will be rendered.
+	 */
+	fallback?: React.ReactNode;
 };
 
 type CreateDefaultSerializerArgs = {
@@ -255,7 +261,7 @@ export const PrismicRichText = (
 
 			return <>{serialized}</>;
 		} else {
-			return null;
+			return props.fallback != null ? <>{props.fallback}</> : null;
 		}
 	}, [
 		props.field,
@@ -263,6 +269,7 @@ export const PrismicRichText = (
 		props.externalLinkComponent,
 		props.components,
 		props.linkResolver,
+		props.fallback,
 		context.linkResolver,
 		context.richTextComponents,
 	]);

--- a/test/PrismicRichText.test.tsx
+++ b/test/PrismicRichText.test.tsx
@@ -35,6 +35,31 @@ test("returns null if passed an empty field", (t) => {
 	t.deepEqual(actualEmpty2, expected);
 });
 
+test("returns fallback if given when passed empty field", (t) => {
+	const fallback = <div>fallback</div>;
+	const actualNull = renderJSON(
+		<PrismicRichText field={null} fallback={fallback} />,
+	);
+	const actualUndefined = renderJSON(
+		<PrismicRichText field={undefined} fallback={fallback} />,
+	);
+	const actualEmpty = renderJSON(
+		<PrismicRichText field={[]} fallback={fallback} />,
+	);
+	const actualEmpty2 = renderJSON(
+		<PrismicRichText
+			field={[{ type: "paragraph", text: "", spans: [] }]}
+			fallback={fallback}
+		/>,
+	);
+	const expected = renderJSON(fallback);
+
+	t.deepEqual(actualNull, expected);
+	t.deepEqual(actualUndefined, expected);
+	t.deepEqual(actualEmpty, expected);
+	t.deepEqual(actualEmpty2, expected);
+});
+
 test("returns <h1> if type is heading1", (t) => {
 	const field: prismicT.RichTextField = [
 		{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds a `fallback` prop to `<PrismicRichText>`. The value given to `fallback` is rendered when `<PrismicRichText>` is given an empty field. If a `fallback` prop is not given, `null` is rendered (this is the existing functionality).

```tsx
<PrismicRichText
  field={document.data.richTextField}
  fallback={<p>Empty content</p>}
/>
```

In this example, `<p>Empty content</p>` is rendered if `document.data.richTextField` is empty (i.e. nullish or contains no content).

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
🦎
