### PR TITLE
fix(`usePrismicClient()`): accept a type parameter to define which documents are supported by the client (e.g. `Content.AllDocumentTypes`)

### DIFF
--- a/src/usePrismicClient.ts
+++ b/src/usePrismicClient.ts
@@ -11,9 +11,11 @@ import { usePrismicContext } from "./usePrismicContext";
  *
  * @returns The `@prismicio/client` instance provided to `<PrismicProvider>`.
  */
-export const usePrismicClient = (
-	explicitClient?: prismic.Client,
-): prismic.Client => {
+export const usePrismicClient = <
+	TDocuments extends prismic.PrismicDocument = prismic.PrismicDocument,
+>(
+	explicitClient?: prismic.Client<TDocuments>,
+): prismic.Client<TDocuments> => {
 	const context = usePrismicContext();
 
 	const client = explicitClient || context?.client;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a bug/limitation in `usePrismicClient()` that did not allow the Prismic client to use content types generated by `prismic-ts-codegen` or Slice Machine.

As of this PR, you can now provide `usePrismicClient()` with a type parameter specifying the content types, just like using `@prismicio/client`'s `createClient()` function directly.

```ts
import type { Content } from "@prismicio/client";
import { usePrismicClient } from "@prismicio/react";

// To provide content types:
const client = usePrismicClient<Content.AllDocumentTypes>();

// A generic client is still supported by not passing a type parameter:
const client = usePrismicClient();
```

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
